### PR TITLE
Replace auth state listener with one-time auth check

### DIFF
--- a/app/src/main/java/com/group2/concord_messenger/LoginActivity.kt
+++ b/app/src/main/java/com/group2/concord_messenger/LoginActivity.kt
@@ -40,44 +40,42 @@ class LoginActivity : AppCompatActivity(), View.OnClickListener
 
         // Launch ChatListActivity if the user is already logged in
         firebaseAuth = FirebaseAuth.getInstance()
-        val mAuthStateListener = FirebaseAuth.AuthStateListener {
-            if (it.currentUser != null) {
-                startActivityClear(this, ChatListActivity::class.java)
-                overridePendingTransition(0, 0)
-                finish()
-            } else {
-                // Otherwise load the page
-                setContentView(R.layout.activity_login)
-                // Get views
-                emailInputLayoutView = findViewById(R.id.login_textlayout_email)
-                passInputLayoutView = findViewById(R.id.login_textlayout_password)
-                emailInputView = findViewById(R.id.login_edittext_email)
-                passInputView = findViewById(R.id.login_edittext_password)
-                loginButtonView = findViewById(R.id.login_button_login)
-                registerButtonView = findViewById(R.id.login_button_register)
-                loginGoogleButtonView = findViewById(R.id.login_button_login_google)
-                progressBarView = findViewById(R.id.login_progress_bar)
+        if(firebaseAuth.currentUser != null) {
+            startActivityClear(this, ChatListActivity::class.java)
+            overridePendingTransition(0, 0)
+        } else {
+            // Otherwise load the page
+            setContentView(R.layout.activity_login)
 
-                this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            // Get views
+            emailInputLayoutView = findViewById(R.id.login_textlayout_email)
+            passInputLayoutView = findViewById(R.id.login_textlayout_password)
+            emailInputView = findViewById(R.id.login_edittext_email)
+            passInputView = findViewById(R.id.login_edittext_password)
+            loginButtonView = findViewById(R.id.login_button_login)
+            registerButtonView = findViewById(R.id.login_button_register)
+            loginGoogleButtonView = findViewById(R.id.login_button_login_google)
+            progressBarView = findViewById(R.id.login_progress_bar)
 
-                loginButtonView.setOnClickListener(this)
-                registerButtonView.setOnClickListener(this)
-                loginGoogleButtonView.setOnClickListener(this)
+            this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
-                inputViews = listOf(
-                    emailInputLayoutView,
-                    passInputLayoutView,
-                )
-                interactableViews = listOf(
-                    emailInputLayoutView,
-                    passInputLayoutView,
-                    loginButtonView,
-                    registerButtonView,
-                    loginGoogleButtonView
-                )
-            }
+            loginButtonView.setOnClickListener(this)
+            registerButtonView.setOnClickListener(this)
+            loginGoogleButtonView.setOnClickListener(this)
+
+            inputViews = listOf(
+                emailInputLayoutView,
+                passInputLayoutView,
+            )
+            interactableViews = listOf(
+                emailInputLayoutView,
+                passInputLayoutView,
+                loginButtonView,
+                registerButtonView,
+                loginGoogleButtonView
+            )
         }
-        firebaseAuth.addAuthStateListener(mAuthStateListener)
+
         getGoogleLoginResultLauncher()
     }
 


### PR DESCRIPTION
Had to remove the auth state listener added [here](https://github.com/CMPT362-Messaging/Concord-Messenger/commit/d5834bc44655a962b8e1ec1b0cc1687f3ecb8c6e). I suspect it was also the cause of the [activity being double loaded](https://github.com/CMPT362-Messaging/Concord-Messenger/pull/15#issuecomment-1203275371)--once when the auth state changes, and once when the login callback chain finishes.