### PR TITLE
Make the "VIEW PROFILE" button's text white

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -31,6 +31,7 @@
                 android:layout_gravity="end"
                 android:layout_marginEnd="15dp"
                 android:text="View Profile"
+                android:textColor="#FFFFFF"
                 style="@style/Widget.MaterialComponents.Button.TextButton"
                 />
         </androidx.appcompat.widget.Toolbar>
@@ -92,8 +93,8 @@
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
             android:layout_marginStart="16dp"
-            android:layout_toEndOf="@+id/photo_button"
             android:layout_toStartOf="@+id/button_gchat_send"
+            android:layout_toEndOf="@+id/photo_button"
             android:background="@android:color/transparent"
             android:hint="Enter Message"
             android:inputType="textCapSentences|textMultiLine"


### PR DESCRIPTION
Allows users with a light theme to see the "VIEW PROFILE" button in `ChatActivity.kt` by hardcoding the text of the button white.